### PR TITLE
Make MailHeaderMap perform case-insensitive searches

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,9 +378,6 @@ pub trait MailHeaderMap {
     /// ```
     fn get_first_value(&self, key: &str) -> Result<Option<String>, MailParseError>;
 
-    /// Same as get_first_value.
-    fn get_first_value_ci(&self, key: &str) -> Result<Option<String>, MailParseError>;
-
     /// Look through the list of headers and return the values of all headers
     /// matching the provided key. Returns an empty vector if no matching headers
     /// were found. The order of the returned values is the same as the order
@@ -398,17 +395,10 @@ pub trait MailHeaderMap {
     ///         vec!["Value1".to_string(), "Value2".to_string()]);
     /// ```
     fn get_all_values(&self, key: &str) -> Result<Vec<String>, MailParseError>;
-
-    /// Same as get_all_values.
-    fn get_all_values_ci(&self, key: &str) -> Result<Vec<String>, MailParseError>;
 }
 
 impl<'a> MailHeaderMap for Vec<MailHeader<'a>> {
     fn get_first_value(&self, key: &str) -> Result<Option<String>, MailParseError> {
-        self.get_first_value_ci(key)
-    }
-
-    fn get_first_value_ci(&self, key: &str) -> Result<Option<String>, MailParseError> {
         let lower_key = key.to_lowercase();
         for x in self {
             if try!(x.get_key()).to_lowercase() == lower_key {
@@ -419,10 +409,6 @@ impl<'a> MailHeaderMap for Vec<MailHeader<'a>> {
     }
 
     fn get_all_values(&self, key: &str) -> Result<Vec<String>, MailParseError> {
-        self.get_all_values_ci(key)
-    }
-
-    fn get_all_values_ci(&self, key: &str) -> Result<Vec<String>, MailParseError> {
         let lower_key = key.to_lowercase();
         let mut values: Vec<String> = Vec::new();
         for x in self {
@@ -583,7 +569,7 @@ impl<'a> ParsedMail<'a> {
     ///     assert_eq!(p.get_body().unwrap(), "This is the body");
     /// ```
     pub fn get_body(&self) -> Result<String, MailParseError> {
-        let transfer_coding = try!(self.headers.get_first_value_ci("Content-Transfer-Encoding"))
+        let transfer_coding = try!(self.headers.get_first_value("Content-Transfer-Encoding"))
             .map(|s| s.to_lowercase());
         let decoded = match transfer_coding.unwrap_or(String::new()).as_ref() {
             "base64" => {
@@ -647,7 +633,7 @@ impl<'a> ParsedMail<'a> {
 /// ```
 pub fn parse_mail(raw_data: &[u8]) -> Result<ParsedMail, MailParseError> {
     let (headers, ix_body) = try!(parse_headers(raw_data));
-    let ctype = match try!(headers.get_first_value_ci("Content-Type")) {
+    let ctype = match try!(headers.get_first_value("Content-Type")) {
         Some(s) => try!(parse_content_type(&s)),
         None => {
             ParsedContentType {


### PR DESCRIPTION
The trait MailHeaderMap has two methods for searching headers, normal
and case-insensitive. This documentation says:

> According to the spec the mail headers are supposed to be
> case-sensitive, but in real-world scenarios that's not always the
> case.

Actually, the spec says nothing that headers supposed to case-sensitive,
and historical precedent is to be case-insensitive. Certainly, all the
mail processing software I am familiar with (Thunderbird, qmail, ezmlm,
and mutt) treat headers as case insensitive. RFC 822 section 3.4.7 says:

> When matching any other syntactic unit, case is to be ignored. For
> example, the field-names "From", "FROM", "from", and even "FroM" are
> semantically equal and should all be treated identically.

While RFC 2822 did drop that section (and RFC 5322 didn't restore it),
others interpret other parts to indicate case insensitivity.

https://stackoverflow.com/a/6143644

> RFC 5322 does actually specify this, but it is very indirect.

https://www.gnu.org/software/emacs/manual/html_node/emacs/Mail-Headers.html

> Upper and lower case are equivalent in field names.

https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi.processors.email.ExtractEmailHeaders/index.html

> NOTE the header key is case insensitive

This change makes all header searches case insensitive.

(NOTE I didn't include changes to target/doc, because my running of "cargo doc" produced changes there that appeared to be completely unrelated to my modifications.)