### PR TITLE
Fix a variety of clippy lint warnings

### DIFF
--- a/src/dateparse.rs
+++ b/src/dateparse.rs
@@ -84,12 +84,9 @@ pub fn dateparse(date: &str) -> Result<i64, &'static str> {
         }
         match state {
             DateParseState::Date => {
-                match tok.parse::<u8>() {
-                    Ok(v) => {
-                        day_of_month = v;
-                        state = DateParseState::Month;
-                    }
-                    Err(_) => (),
+                if let Ok(v) = tok.parse::<u8>() {
+                    day_of_month = v;
+                    state = DateParseState::Month;
                 };
                 continue;
             }

--- a/src/dateparse.rs
+++ b/src/dateparse.rs
@@ -117,7 +117,7 @@ pub fn dateparse(date: &str) -> Result<i64, &'static str> {
                     Ok(v) => v,
                     Err(_) => return Err("Invalid year"),
                 };
-                result = seconds_to_date(year as i64, month as i64, day_of_month as i64);
+                result = seconds_to_date(i64::from(year), i64::from(month), i64::from(day_of_month));
                 state = DateParseState::Hour;
                 continue;
             }
@@ -126,7 +126,7 @@ pub fn dateparse(date: &str) -> Result<i64, &'static str> {
                     Ok(v) => v,
                     Err(_) => return Err("Invalid hour"),
                 };
-                result += 3600 * (hour as i64);
+                result += 3600 * i64::from(hour);
                 state = DateParseState::Minute;
                 continue;
             }
@@ -135,7 +135,7 @@ pub fn dateparse(date: &str) -> Result<i64, &'static str> {
                     Ok(v) => v,
                     Err(_) => return Err("Invalid minute"),
                 };
-                result += 60 * (minute as i64);
+                result += 60 * i64::from(minute);
                 state = DateParseState::Second;
                 continue;
             }
@@ -144,7 +144,7 @@ pub fn dateparse(date: &str) -> Result<i64, &'static str> {
                     Ok(v) => v,
                     Err(_) => return Err("Invalid second"),
                 };
-                result += second as i64;
+                result += i64::from(second);
                 state = DateParseState::Timezone;
                 continue;
             }
@@ -173,9 +173,9 @@ pub fn dateparse(date: &str) -> Result<i64, &'static str> {
                 let tz_mins = tz % 100;
                 let tz_delta = (tz_hours * 3600) + (tz_mins * 60);
                 if tz_sign < 0 {
-                    result += tz_delta as i64;
+                    result += i64::from(tz_delta);
                 } else {
-                    result -= tz_delta as i64;
+                    result -= i64::from(tz_delta);
                 }
                 break;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,8 +554,8 @@ pub fn parse_content_type(header: &str) -> ParsedContentType {
     );
 
     ParsedContentType {
-        mimetype: mimetype,
-        charset: charset,
+        mimetype,
+        charset,
         params: params.params,
     }
 }
@@ -628,7 +628,7 @@ pub fn parse_content_disposition(header: &str) -> ParsedContentDisposition {
     let params = parse_param_content(header);
     let disposition = parse_disposition_type(&params.value);
     ParsedContentDisposition {
-        disposition: disposition,
+        disposition,
         params: params.params,
     }
 }
@@ -775,8 +775,8 @@ pub fn parse_mail(raw_data: &[u8]) -> Result<ParsedMail, MailParseError> {
         .unwrap_or_default();
 
     let mut result = ParsedMail {
-        headers: headers,
-        ctype: ctype,
+        headers,
+        ctype,
         body: &raw_data[ix_body..],
         subparts: Vec::<ParsedMail>::new(),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,9 +549,11 @@ impl Default for ParsedContentType {
 pub fn parse_content_type(header: &str) -> ParsedContentType {
     let params = parse_param_content(header);
     let mimetype = params.value.to_lowercase();
-    let charset = params.params.get("charset").cloned().unwrap_or(
-        "us-ascii".to_string(),
-    );
+    let charset = params
+        .params
+        .get("charset")
+        .cloned()
+        .unwrap_or_else(|| "us-ascii".to_string());
 
     ParsedContentType {
         mimetype,
@@ -694,7 +696,7 @@ impl<'a> ParsedMail<'a> {
     pub fn get_body_raw(&self) -> Result<Vec<u8>, MailParseError> {
         let transfer_coding = try!(self.headers.get_first_value("Content-Transfer-Encoding"))
             .map(|s| s.to_lowercase());
-        let decoded = match transfer_coding.unwrap_or(String::new()).as_ref() {
+        let decoded = match transfer_coding.unwrap_or_default().as_ref() {
             "base64" => {
                 let cleaned = self.body
                     .iter()
@@ -791,7 +793,8 @@ pub fn parse_mail(raw_data: &[u8]) -> Result<ParsedMail, MailParseError> {
                 find_from_u8(raw_data, ix_boundary_end, b"\n").map(|v| v + 1)
             {
                 // if there is no terminating boundary, assume the part end is the end of the email
-                let ix_part_end = find_from_u8(raw_data, ix_part_start, boundary.as_bytes()).unwrap_or(raw_data.len());
+                let ix_part_end = find_from_u8(raw_data, ix_part_start, boundary.as_bytes())
+                    .unwrap_or_else(|| raw_data.len());
 
                 result.subparts.push(try!(parse_mail(
                     &raw_data[ix_part_start..ix_part_end],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ impl<'a> MailHeaderMap for Vec<MailHeader<'a>> {
     fn get_first_value(&self, key: &str) -> Result<Option<String>, MailParseError> {
         for x in self {
             if try!(x.get_key()).eq_ignore_ascii_case(key) {
-                return x.get_value().map(|v| Some(v));
+                return x.get_value().map(Some);
             }
         }
         Ok(None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,7 +785,7 @@ pub fn parse_mail(raw_data: &[u8]) -> Result<ParsedMail, MailParseError> {
     if result.ctype.mimetype.starts_with("multipart/") &&
         result.ctype.params.get("boundary").is_some() && raw_data.len() > ix_body
     {
-        let boundary = String::from("--") + result.ctype.params.get("boundary").unwrap();
+        let boundary = String::from("--") + &result.ctype.params["boundary"];
         if let Some(ix_body_end) = find_from_u8(raw_data, ix_body, boundary.as_bytes()) {
             result.body = &raw_data[ix_body..ix_body_end];
             let mut ix_boundary_end = ix_body_end + boundary.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,12 +205,7 @@ impl<'a> MailHeader<'a> {
         ));
         let mut lines = chars.lines();
         let mut add_space = false;
-        loop {
-            let line = match lines.next() {
-                Some(v) => v.trim_left(),
-                None => break,
-            };
-
+        while let Some(line) = lines.next().map(str::trim_left) {
             if add_space {
                 result.push(' ');
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl<'a> MailHeader<'a> {
     }
 
     fn decode_word(&self, encoded: &str) -> Option<String> {
-        let ix_delim1 = try_none!(encoded.find("?"));
+        let ix_delim1 = try_none!(encoded.find('?'));
         let ix_delim2 = try_none!(find_from(encoded, ix_delim1 + 1, "?"));
 
         let charset = &encoded[0..ix_delim1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ impl<'a> MailHeader<'a> {
                             };
                             break;
                         }
-                        ix_search = ix_search + 2;
+                        ix_search += 2;
                         continue;
                     }
                     None => {
@@ -351,7 +351,7 @@ pub fn parse_header(raw_data: &[u8]) -> Result<(MailHeader, usize), MailParseErr
                 }
             }
         }
-        ix = ix + 1;
+        ix += 1;
         c = match it.next() {
             None => break,
             Some(v) => *v,
@@ -464,11 +464,11 @@ pub fn parse_headers(raw_data: &[u8]) -> Result<(Vec<MailHeader>, usize), MailPa
         if ix >= raw_data.len() {
             break;
         } else if raw_data[ix] == b'\n' {
-            ix = ix + 1;
+            ix += 1;
             break;
         } else if raw_data[ix] == b'\r' {
             if ix + 1 < raw_data.len() && raw_data[ix + 1] == b'\n' {
-                ix = ix + 2;
+                ix += 2;
                 break;
             } else {
                 return Err(MailParseError::Generic(
@@ -479,7 +479,7 @@ pub fn parse_headers(raw_data: &[u8]) -> Result<(Vec<MailHeader>, usize), MailPa
         }
         let (header, ix_next) = try!(parse_header(&raw_data[ix..]));
         headers.push(header);
-        ix = ix + ix_next;
+        ix += ix_next;
     }
     Ok((headers, ix))
 }


### PR DESCRIPTION
This leaves precisely one clippy warning:

```
warning: length comparison to zero
   --> src/lib.rs:110:13
    |
110 |     assert!(key.len() > 0);
    |             ^^^^^^^^^^^^^ help: using `is_empty` is more concise: `!key.is_empty()`
    |
    = note: #[warn(len_zero)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#len_zero
```

Not sure I agree with clippy in this particular case.