### PR TITLE
Tidy Result/Option use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@ use std::collections::BTreeMap;
 
 use encoding::Encoding;
 
-#[macro_use]
-mod macros;
 mod dateparse;
 
 pub use dateparse::dateparse;
@@ -147,15 +145,15 @@ impl<'a> MailHeader<'a> {
     }
 
     fn decode_word(&self, encoded: &str) -> Option<String> {
-        let ix_delim1 = try_none!(encoded.find('?'));
-        let ix_delim2 = try_none!(find_from(encoded, ix_delim1 + 1, "?"));
+        let ix_delim1 = encoded.find('?')?;
+        let ix_delim2 = find_from(encoded, ix_delim1 + 1, "?")?;
 
         let charset = &encoded[0..ix_delim1];
         let transfer_coding = &encoded[ix_delim1 + 1..ix_delim2];
         let input = &encoded[ix_delim2 + 1..];
 
         let decoded = match transfer_coding {
-            "B" | "b" => try_none!(base64::decode(input.as_bytes()).ok()),
+            "B" | "b" => base64::decode(input.as_bytes()).ok()?,
             "Q" | "q" => {
                 // The quoted_printable module does a trim_right on the input, so if
                 // that affects the output we should save and restore the trailing
@@ -169,11 +167,11 @@ impl<'a> MailHeader<'a> {
                         to_decode[trimmed.len()..].as_bytes(),
                     );
                 }
-                try_none!(d.ok())
+                d.ok()?
             }
             _ => return None,
         };
-        let charset_conv = try_none!(encoding::label::encoding_from_whatwg_label(charset));
+        let charset_conv = encoding::label::encoding_from_whatwg_label(charset)?;
         charset_conv
             .decode(&decoded, encoding::DecoderTrap::Replace)
             .ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,13 +142,10 @@ fn test_find_from_u8() {
 impl<'a> MailHeader<'a> {
     /// Get the name of the header. Note that header names are case-insensitive.
     pub fn get_key(&self) -> Result<String, MailParseError> {
-        Ok(
-            try!(encoding::all::ISO_8859_1.decode(
-                self.key,
-                encoding::DecoderTrap::Strict,
-            )).trim()
-                .to_string(),
-        )
+        encoding::all::ISO_8859_1
+            .decode(self.key, encoding::DecoderTrap::Strict)
+            .map(|s| s.trim().to_string())
+            .map_err(MailParseError::EncodingError)
     }
 
     fn decode_word(&self, encoded: &str) -> Option<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,11 +95,9 @@ pub struct MailHeader<'a> {
 }
 
 fn is_boundary(line: &str, ix: Option<usize>) -> bool {
-    ix.map(|v| {
-        line.chars().nth(v).map_or(true, |c| {
-            c.is_whitespace() || c == '"' || c == '(' || c == ')' || c == '<' || c == '>'
-        })
-    }).unwrap_or(true)
+    ix.and_then(|v| line.chars().nth(v))
+        .map(|c| c.is_whitespace() || c == '"' || c == '(' || c == ')' || c == '<' || c == '>')
+        .unwrap_or(true)
 }
 
 fn find_from(line: &str, ix_start: usize, key: &str) -> Option<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,12 +682,11 @@ impl<'a> ParsedMail<'a> {
             .map(|s| s.to_lowercase());
         let decoded = match transfer_coding.unwrap_or_default().as_ref() {
             "base64" => {
-                let cleaned = self.body
+                let cleaned = self
+                    .body
                     .iter()
-                    .filter_map(|&c| match c {
-                        b' ' | b'\t' | b'\r' | b'\n' => None,
-                        v => Some(v),
-                    })
+                    .filter(|c| !c.is_ascii_whitespace())
+                    .cloned()
                     .collect::<Vec<u8>>();
                 base64::decode(&cleaned)?
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,17 +813,16 @@ fn parse_param_content(content: &str) -> ParamContent {
     // There must be at least one token produced by split, even if it's empty.
     let value = tokens.next().unwrap().trim();
     let map = tokens
-        .filter_map(|kv| if let Some(idx) = kv.find('=') {
-            let key = kv[0..idx].trim().to_lowercase();
-            let mut value = kv[idx + 1..].trim();
-            if value.starts_with('"') && value.ends_with('"') {
-                value = &value[1..value.len() - 1];
-            }
-            Some((key, value.to_string()))
-        } else {
-            None
-        })
-        .collect();
+        .filter_map(|kv| {
+            kv.find('=').map(|idx| {
+                let key = kv[0..idx].trim().to_lowercase();
+                let mut value = kv[idx + 1..].trim();
+                if value.starts_with('"') && value.ends_with('"') {
+                    value = &value[1..value.len() - 1];
+                }
+                (key, value.to_string())
+            })
+        }).collect();
 
     ParamContent {
         value: value.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ impl<'a> MailHeader<'a> {
         encoding::all::ISO_8859_1
             .decode(self.key, encoding::DecoderTrap::Strict)
             .map(|s| s.trim().to_string())
-            .map_err(MailParseError::EncodingError)
+            .map_err(|e| e.into())
     }
 
     fn decode_word(&self, encoded: &str) -> Option<String> {
@@ -657,8 +657,8 @@ impl<'a> ParsedMail<'a> {
         let decoded = self.get_body_raw()?;
         let charset_conv = encoding::label::encoding_from_whatwg_label(&self.ctype.charset)
             .unwrap_or(encoding::all::ASCII);
-        let str_body = charset_conv.decode(&decoded, encoding::DecoderTrap::Replace)?;
-        Ok(str_body)
+        charset_conv.decode(&decoded, encoding::DecoderTrap::Replace)
+            .map_err(|e| e.into())
     }
 
     /// Get the body of the message as a Rust Vec<u8>. This function tries to

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,0 @@
-macro_rules! try_none {
-    ( $x:expr ) => {{
-        match $x {
-            Some(v) => v,
-            None => return None,
-        }
-    }}
-}


### PR DESCRIPTION
Removes use of `try!` and `try_none!`, amongst various other cleanups.

7eda2c0 slightly changes base64 handling: vertical tabs weren't getting stripped.  I think this is reasonable.