### PR TITLE
Add UTF-7 support by using the charset crate instead of the encoding crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 base64 = "0.9.0"
 quoted_printable = "0.4.0"
-encoding = "0.2.32"
+charset = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -945,6 +945,22 @@ mod tests {
             "[Ontario Builder] Understanding home shopping \u{2013} a quick survey"
         );
 
+        let (parsed, _) = parse_header(b"Subject: =?ISO-2022-JP?B?GyRCRnwbKEI=?=\n\t=?ISO-2022-JP?B?GyRCS1wbKEI=?=\n\t=?ISO-2022-JP?B?GyRCOGwbKEI=?=")
+            .unwrap();
+        assert_eq!(parsed.get_key().unwrap(), "Subject");
+        assert_eq!(
+            parsed.get_value().unwrap(),
+            "\u{65E5}\u{672C}\u{8A9E}"
+        );
+
+        let (parsed, _) = parse_header(b"Subject: =?ISO-2022-JP?Q?=1B\x24\x42\x46\x7C=1B\x28\x42?=\n\t=?ISO-2022-JP?Q?=1B\x24\x42\x4B\x5C=1B\x28\x42?=\n\t=?ISO-2022-JP?Q?=1B\x24\x42\x38\x6C=1B\x28\x42?=")
+            .unwrap();
+        assert_eq!(parsed.get_key().unwrap(), "Subject");
+        assert_eq!(
+            parsed.get_value().unwrap(),
+            "\u{65E5}\u{672C}\u{8A9E}"
+        );
+
         let (parsed, _) = parse_header(
             b"Content-Type: image/jpeg; name=\"=?UTF-8?B?MDY2MTM5ODEuanBn?=\"",
         ).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,6 +961,14 @@ mod tests {
             "\u{65E5}\u{672C}\u{8A9E}"
         );
 
+        let (parsed, _) = parse_header(b"Subject: =?UTF-7?Q?+JgM-?=")
+            .unwrap();
+        assert_eq!(parsed.get_key().unwrap(), "Subject");
+        assert_eq!(
+            parsed.get_value().unwrap(),
+            "\u{2603}"
+        );
+
         let (parsed, _) = parse_header(
             b"Content-Type: image/jpeg; name=\"=?UTF-8?B?MDY2MTM5ODEuanBn?=\"",
         ).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1173,6 +1173,19 @@ mod tests {
         assert_eq!(mail.ctype.mimetype, "text/html");
         assert_eq!(mail.get_body_raw().unwrap(), b"hello world");
         assert_eq!(mail.get_body().unwrap(), "hello world");
+
+        let mail = parse_mail(
+            b"Content-Type: text/plain; charset=UTF-7\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n+JgM-",
+        ).unwrap();
+        assert_eq!(mail.get_body_raw().unwrap(), b"+JgM-");
+        assert_eq!(mail.get_body().unwrap(), "\u{2603}");
+
+        let mail = parse_mail(
+            b"Content-Type: text/plain; charset=UTF-7\r\n\r\n+JgM-",
+        ).unwrap();
+        assert_eq!(mail.get_body_raw().unwrap(), b"+JgM-");
+        assert_eq!(mail.get_body().unwrap(), "\u{2603}");
+
     }
 
     #[test]


### PR DESCRIPTION
[`charset`](https://crates.io/crates/charset) is a crate that provides Thunderbird-compatible decoding of character encodings in email by implementing UTF-7 and wrapping [`encoding_rs`](https://crates.io/crates/encoding_rs) for the rest. (Thunderbird uses encoding_rs for non-UTF-7 encodings.)

This PR replaces the dependency on `encoding` with a dependency on `charset`. Apart from performance differences, the only observable behavior changes should be 1) the addition of UTF-7 support, 2) the removal of HZ support, 3) honoring the BOM in email bodies (unclear if appropriate), and 4) a spec change to the mapping of one byte in windows-1255 (Hebrew). Experience from Thunderbird and the Firefox OS email client suggests that UTF-7 decode support is still need. (But Thunderbird has gotten away with dropping HZ.)

`charset` is an edition 2018 crate, so it probably makes sense to wait until edition 2018 becomes available on stable before merging.