### PR TITLE
fixing docs.rs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Example usage
 
 Documentation
 ---
-See the rustdoc at [https://docs.rs/mailparse/](docs.rs).
+See the rustdoc at [docs.rs](https://docs.rs/mailparse/).
 
 Other notes
 ---


### PR DESCRIPTION
it appears these are in reverse order - docs.rs is obviously not a valid url