### PR TITLE
Add into_inner to MailAddrList

### DIFF
--- a/src/addrparse.rs
+++ b/src/addrparse.rs
@@ -170,6 +170,11 @@ impl MailAddrList {
             None
         }
     }
+
+    /// Consumes the `MailAddrList`, returning the wrapped value.
+    pub fn into_inner(self) -> Vec<MailAddr> {
+        self.0
+    }
 }
 
 enum HeaderTokenItem<'a> {


### PR DESCRIPTION
This adds the ability to consume the inner MailAddrs and thus let's
users avoid clones in some scenarios.