### PR TITLE
updates base64 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ travis-ci = { repository = "staktrace/mailparse" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-base64 = "0.10.0"
+base64 = "0.12"
 quoted_printable = "0.4.2"
 charset = "0.1.1"


### PR DESCRIPTION
See also #67, except this is the latest one, all tests passed locally. 

There is no reason other than to minimize the dependency tree and to get rid of the following issues when used along other crates such as latest `imap`:

```console
$ cargo doc
warning: output filename collision.
The lib target `base64` in package `base64 v0.12.2` has the same output filename as the lib target `base64` in package `base64 v0.10.1`.
Colliding filename is: /home/user/projects/mail/target/doc/base64/index.html

$ cargo clippy
warning: multiple versions for dependency `base64`: 0.10.1, 0.11.0, 0.12.2
```