### PR TITLE
msgidparse: make whitespace separating message ids optional

### DIFF
--- a/src/msgidparse.rs
+++ b/src/msgidparse.rs
@@ -64,3 +64,45 @@ pub fn msgidparse(ids: &str) -> Result<MessageIdList, MailParseError> {
     }
     Ok(MessageIdList(msgids))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_message_ids() {
+        assert_eq!(
+            msgidparse("").expect("Empty string"),
+            MessageIdList(Vec::new())
+        );
+        assert_eq!(
+            msgidparse("<msg_one@foo.com>").expect("Single reference"),
+            MessageIdList(vec!["msg_one@foo.com".to_string()])
+        );
+        assert_eq!(
+            msgidparse(" <msg_one@foo.com>").expect("Single reference, leading whitespace"),
+            MessageIdList(vec!["msg_one@foo.com".to_string()])
+        );
+        assert_eq!(
+            msgidparse("<msg_one@foo.com> ").expect("Single reference, trailing whitespace"),
+            MessageIdList(vec!["msg_one@foo.com".to_string()])
+        );
+        assert_eq!(
+            msgidparse("<msg_one@foo.com> <msg_two@bar.com>")
+                .expect("Multiple references separated by space"),
+            MessageIdList(vec![
+                "msg_one@foo.com".to_string(),
+                "msg_two@bar.com".to_string(),
+            ])
+        );
+        assert_eq!(
+            msgidparse("\n<msg_one@foo.com> <msg_two@bar.com>\t<msg_three@qux.com>\r ")
+                .expect("Multiple references separated by various whitespace"),
+            MessageIdList(vec![
+                "msg_one@foo.com".to_string(),
+                "msg_two@bar.com".to_string(),
+                "msg_three@qux.com".to_string(),
+            ])
+        );
+    }
+}


### PR DESCRIPTION
Closes #72 

This PR:

- adds a benchmark using [criterion](https://github.com/bheisler/criterion.rs) for the current `msgidparse` function
- covers the existing `msgidparse` function with unit tests
- updates the implementation of `msgidparse` to make separator whitespace optional, as per  [RFC5322](https://tools.ietf.org/html/rfc5322#section-3.6.4) 

## Benchmark results

**No significant decrease** in speed was seen for short or long inputs to `msgidparse`.

### master

```log
msgidparse single id    time:   [74.461 ns 74.700 ns 74.958 ns]
msgidparse many ids     time:   [8.0999 us 8.1436 us 8.1853 us]
```

### This PR

```log
msgidparse single id    time:   [75.269 ns 75.839 ns 76.397 ns]
                        change: [+0.1514% +0.8757% +1.6172%] (p = 0.02 < 0.05)
                        Change within noise threshold.
msgidparse many ids     time:   [8.1968 us 8.2692 us 8.3627 us]
                        change: [-0.1450% +1.0312% +2.5808%] (p = 0.15 > 0.05)
                        No change in performance detected.
```
