### PR TITLE
Rewrite API to be owning

### DIFF
--- a/src/addrparse.rs
+++ b/src/addrparse.rs
@@ -286,7 +286,7 @@ pub fn addrparse(addrs: &str) -> Result<MailAddrList, MailParseError> {
 ///     };
 /// ```
 pub fn addrparse_header(header: &MailHeader) -> Result<MailAddrList, MailParseError> {
-    let chars = decode_latin1(header.value);
+    let chars = decode_latin1(&header.value);
     let v = crate::header::normalized_tokens(&chars);
     let mut w = HeaderTokenWalker::new(v);
     addrparse_inner(&mut w, false)


### PR DESCRIPTION
This patch rewrites the API so that the objects returned by it actually
_own_ the data they parse.

This is necessary to write convenient Rust code on the users side.

---

I managed, after some hours of trial-and-error, to rewrite the API to own the data that is parsed.
There are some `clone()` calls in here, but I actually do not mind. 

I did not yet use this new API, but I'm going to.