### PR TITLE
Add a failing test for addrparse_header

### DIFF
--- a/src/addrparse.rs
+++ b/src/addrparse.rs
@@ -1062,5 +1062,26 @@ mod tests {
                 .unwrap()
             )])
         );
+
+        let (parsed, _) = crate::parse_header(
+            b"To: foo <foo@example.org>,?UTF-8?B?Zm9v8J+Qm2Jhcg==?= <bar@example.org>",
+        )
+        .unwrap();
+        assert_eq!(
+            addrparse_header(&parsed).unwrap(),
+            MailAddrList(vec![
+                MailAddr::Single(
+                    SingleInfo::new(Some("foo".to_string()), "foo@example.org".to_string())
+                        .unwrap()
+                ),
+                MailAddr::Single(
+                    SingleInfo::new(
+                        Some("foo\u{1f41b}bar".to_string()),
+                        "bar@example.org".to_string()
+                    )
+                    .unwrap()
+                )
+            ])
+        );
     }
 }


### PR DESCRIPTION
Mailbox name is only decoded if it is first in the list. In the test,
the second mailbox name is not decoded.