### PR TITLE
Add custom Debug trait for Headers and MailHeader

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,4 +1,5 @@
 use crate::{MailHeader, MailHeaderMap};
+use std::fmt;
 use std::slice;
 
 /// A struct that wrapps the header portion of a message and provides
@@ -53,6 +54,30 @@ impl<'a> IntoIterator for Headers<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.headers.into_iter()
+    }
+}
+
+/// Allows formatting and printing the `Headers` struct items.
+///
+/// # Examples
+/// ```
+///     use mailparse::parse_mail;
+///     let mail = parse_mail(concat!(
+///             "Subject: foo\n",
+///             "Another header: bar\n",
+///             "\n",
+///             "Body starts here").as_bytes())
+///         .unwrap();
+///     let mut headers = mail.get_headers();
+///     assert_eq!(format!("{:?}", headers), "Headers { \
+///                headers: [MailHeader { key: \"Subject\", value: \"foo\" }, \
+///                MailHeader { key: \"Another header\", value: \"bar\" }] }");
+/// ```
+impl<'a> fmt::Debug for Headers<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Headers")
+            .field("headers", &self.headers)
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,19 @@ impl From<std::borrow::Cow<'static, str>> for MailParseError {
 /// lifetime of this struct must be contained within the lifetime of the raw
 /// input. There are additional accessor functions on this struct to extract
 /// the data as Rust strings.
-#[derive(Debug)]
 pub struct MailHeader<'a> {
     key: &'a [u8],
     value: &'a [u8],
+}
+
+/// Custom Debug trait for better formatting and printing of MailHeader items.
+impl<'a> fmt::Debug for MailHeader<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MailHeader")
+            .field("key", &String::from_utf8_lossy(&self.key))
+            .field("value", &String::from_utf8_lossy(&self.value))
+            .finish()
+    }
 }
 
 pub(crate) fn find_from(line: &str, ix_start: usize, key: &str) -> Option<usize> {


### PR DESCRIPTION
In order to allow better formatting and printing of `Headers`, add custom
Debug traits that convert `MailHeader` items into legible strings and
allow printing the content of `Headers` struct.

Addresses issue #83 