### PR TITLE
Switch base64 implementation to data_encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ exclude = [".gitattributes", ".gitignore", ".github/**", "examples/**"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-base64 = "0.13"
+data-encoding = "2.3.2"
 quoted_printable = "0.4.3"
 charset = "0.1.1"

--- a/src/body.rs
+++ b/src/body.rs
@@ -141,7 +141,7 @@ fn decode_base64(body: &[u8]) -> Result<Vec<u8>, MailParseError> {
         .filter(|c| !c.is_ascii_whitespace())
         .cloned()
         .collect::<Vec<u8>>();
-    Ok(base64::decode(&cleaned)?)
+    Ok(data_encoding::BASE64_MIME.decode(&cleaned)?)
 }
 
 fn decode_quoted_printable(body: &[u8]) -> Result<Vec<u8>, MailParseError> {

--- a/src/header.rs
+++ b/src/header.rs
@@ -45,7 +45,7 @@ fn decode_word(encoded: &str) -> Option<String> {
     let input = &encoded[ix_delim2 + 1..];
 
     let decoded = match transfer_coding {
-        "B" | "b" => base64::decode(input.as_bytes()).ok()?,
+        "B" | "b" => data_encoding::BASE64_MIME.decode(input.as_bytes()).ok()?,
         "Q" | "q" => {
             // The quoted_printable module does a trim_end on the input, so if
             // that affects the output we should save and restore the trailing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
-extern crate data_encoding;
 extern crate charset;
+extern crate data_encoding;
 extern crate quoted_printable;
 
 use std::borrow::Cow;
@@ -1760,8 +1760,10 @@ mod tests {
 
     #[test]
     fn test_base64_content_encoding_multiple_strings() {
-        let mail =
-            parse_mail(b"Content-Transfer-Encoding: base64\r\n\r\naGVsbG 8gd\r\n29ybGQ=\r\nZm9vCg==").unwrap();
+        let mail = parse_mail(
+            b"Content-Transfer-Encoding: base64\r\n\r\naGVsbG 8gd\r\n29ybGQ=\r\nZm9vCg==",
+        )
+        .unwrap();
         match mail.get_body_encoded() {
             Body::Base64(body) => {
                 assert_eq!(body.get_raw(), b"aGVsbG 8gd\r\n29ybGQ=\r\nZm9vCg==");
@@ -1771,7 +1773,6 @@ mod tests {
             _ => assert!(false),
         };
     }
-
 
     #[test]
     fn test_binary_content_encoding() {


### PR DESCRIPTION
This has the main benefit of supporting concatenated base64 strings that
frequently occur within emails.

See
https://github.com/ia0/data-encoding/blob/master/lib/src/lib.rs#L2266-L2283
for details on the implementation.