### PR TITLE
Upgrade charset to v0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 data-encoding = "2.3.2"
 quoted_printable = "0.4.3"
-charset = "0.1.1"
+charset = "0.1.3"
 
 [dev-dependencies]
 ouroboros = "0.14.0"


### PR DESCRIPTION
This removes the `byteorder` dependency and gets both libraries on the same `base64`

Thanks for this library! It's a key component to a project I'm working on, [crabmail](https://git.alexwennerberg.com/crabmail/)