### PR TITLE
Decode raw header bytes as UTF-8 instead of ISO-8859-1 Latin1

### DIFF
--- a/examples/dump_mail.rs
+++ b/examples/dump_mail.rs
@@ -9,21 +9,20 @@ use mailparse::MailHeaderMap;
 fn dump(pfx: &str, pm: &mailparse::ParsedMail) {
     println!(">> Headers from {} <<", pfx);
     for h in &pm.headers {
-        println!("  [{}] => [{}]", h.get_key(), h.get_value());
+        println!(
+            "  [{}] => [{}]",
+            h.get_key().unwrap(),
+            h.get_value().unwrap()
+        );
     }
+
     println!(">> Addresses from {} <<", pfx);
-    pm.headers
-        .get_first_value("From")
-        .map(|a| println!("{:?}", mailparse::addrparse(&a).unwrap()));
-    pm.headers
-        .get_first_value("To")
-        .map(|a| println!("{:?}", mailparse::addrparse(&a).unwrap()));
-    pm.headers
-        .get_first_value("Cc")
-        .map(|a| println!("{:?}", mailparse::addrparse(&a).unwrap()));
-    pm.headers
-        .get_first_value("Bcc")
-        .map(|a| println!("{:?}", mailparse::addrparse(&a).unwrap()));
+    for address_header in ["From", "To", "Cc", "Bcc"] {
+        if let Some(Ok(addresses)) = pm.headers.get_first_value(address_header) {
+            println!("{:?}", mailparse::addrparse(&addresses).unwrap());
+        }
+    }
+
     println!(">> Body from {} <<", pfx);
     if pm.ctype.mimetype.starts_with("text/") {
         println!("  [{}]", pm.get_body().unwrap());
@@ -34,11 +33,12 @@ fn dump(pfx: &str, pm: &mailparse::ParsedMail) {
             pm.get_body().unwrap().len()
         );
     }
+
     let mut c = 1;
     for s in &pm.subparts {
         println!(">> Subpart {} <<", c);
         dump("subpart", s);
-        c = c + 1;
+        c += 1;
     }
 }
 

--- a/src/addrparse.rs
+++ b/src/addrparse.rs
@@ -18,7 +18,7 @@ impl SingleInfo {
         if addr.contains('@') {
             Ok(SingleInfo {
                 display_name: name,
-                addr: addr,
+                addr,
             })
         } else {
             Err(MailParseError::Generic(
@@ -50,7 +50,7 @@ impl GroupInfo {
     fn new(name: String, addrs: Vec<SingleInfo>) -> Self {
         GroupInfo {
             group_name: name,
-            addrs: addrs,
+            addrs,
         }
     }
 }
@@ -424,10 +424,14 @@ fn addrparse_inner(
                             // I think technically not valid, but this occurs in real-world corpus, so
                             // handle gracefully
                             if c == '"' {
-                                post_quote_ws.map(|ws| name.as_mut().unwrap().push_str(&ws));
+                                if let Some(ws) = post_quote_ws {
+                                    name.as_mut().unwrap().push_str(&ws)
+                                }
                                 state = AddrParseState::QuotedName;
                             } else {
-                                post_quote_ws.map(|ws| name.as_mut().unwrap().push_str(&ws));
+                                if let Some(ws) = post_quote_ws {
+                                    name.as_mut().unwrap().push_str(&ws)
+                                }
                                 name.as_mut().unwrap().push(c);
                             }
                             post_quote_ws = None;
@@ -446,7 +450,9 @@ fn addrparse_inner(
                         post_quote_ws.as_mut().unwrap().push_str(&ws);
                     }
                     HeaderTokenItem::DecodedWord(word) => {
-                        post_quote_ws.map(|ws| name.as_mut().unwrap().push_str(&ws));
+                        if let Some(ws) = post_quote_ws {
+                            name.as_mut().unwrap().push_str(&ws)
+                        }
                         name.as_mut().unwrap().push_str(&word);
                         post_quote_ws = None;
                     }

--- a/src/body.rs
+++ b/src/body.rs
@@ -77,7 +77,7 @@ impl<'a> EncodedBody<'a> {
     /// This operation returns a valid result only if the decoded body
     /// has a text format.
     pub fn get_decoded_as_string(&self) -> Result<String, MailParseError> {
-        get_body_as_string(&self.get_decoded()?, &self.ctype)
+        get_body_as_string(&self.get_decoded()?, self.ctype)
     }
 }
 
@@ -103,7 +103,7 @@ impl<'a> TextBody<'a> {
     /// in the Content-Type
     /// (or "us-ascii" if the charset was missing or not recognized).
     pub fn get_as_string(&self) -> Result<String, MailParseError> {
-        get_body_as_string(self.body, &self.ctype)
+        get_body_as_string(self.body, self.ctype)
     }
 }
 
@@ -131,7 +131,7 @@ impl<'a> BinaryBody<'a> {
     /// convenient handling of real-world emails that may provide textual data
     /// with a binary transfer encoding, but use this at your own risk!
     pub fn get_as_string(&self) -> Result<String, MailParseError> {
-        get_body_as_string(self.body, &self.ctype)
+        get_body_as_string(self.body, self.ctype)
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -50,7 +50,7 @@ fn decode_word(encoded: &str) -> Option<String> {
             // The quoted_printable module does a trim_end on the input, so if
             // that affects the output we should save and restore the trailing
             // whitespace
-            let to_decode = input.replace("_", " ");
+            let to_decode = input.replace('_', " ");
             let trimmed = to_decode.trim_end();
             let mut d = quoted_printable::decode(&trimmed, quoted_printable::ParseMode::Robust);
             if d.is_ok() && to_decode.len() != trimmed.len() {
@@ -72,7 +72,7 @@ fn decode_word(encoded: &str) -> Option<String> {
 /// generate `HeaderToken::Newline` tokens.
 fn tokenize_header_line(line: &str) -> Vec<HeaderToken> {
     fn maybe_whitespace(text: &str) -> HeaderToken {
-        if text.trim_end().len() == 0 {
+        if text.trim_end().is_empty() {
             HeaderToken::Whitespace(text)
         } else {
             HeaderToken::Text(text)
@@ -215,7 +215,7 @@ fn normalize_header_whitespace(tokens: Vec<HeaderToken>) -> Vec<HeaderToken> {
 }
 
 pub fn normalized_tokens(raw_value: &str) -> Vec<HeaderToken> {
-    normalize_header_whitespace(tokenize_header(&raw_value))
+    normalize_header_whitespace(tokenize_header(raw_value))
 }
 
 #[cfg(test)]

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,4 +1,4 @@
-use crate::{MailHeader, MailHeaderMap};
+use crate::{MailHeader, MailHeaderMap, Result};
 use std::fmt;
 use std::slice;
 
@@ -45,8 +45,8 @@ impl<'a> Headers<'a> {
 ///             "Body starts here").as_bytes())
 ///         .unwrap();
 ///     let mut iter = mail.get_headers().into_iter();
-///     assert_eq!(iter.next().unwrap().get_key(), "Subject");
-///     assert_eq!(iter.next().unwrap().get_key(), "Another header");
+///     assert_eq!(iter.next().unwrap().get_key().unwrap(), "Subject");
+///     assert_eq!(iter.next().unwrap().get_key().unwrap(), "Another header");
 /// ```
 impl<'a> IntoIterator for Headers<'a> {
     type Item = &'a MailHeader<'a>;
@@ -90,9 +90,9 @@ impl<'a> MailHeaderMap for Headers<'a> {
     ///             "\n",
     ///             "This is a test message").as_bytes())
     ///         .unwrap();
-    ///     assert_eq!(mail.get_headers().get_first_value("Subject"), Some("Test".to_string()));
+    ///     assert_eq!(mail.get_headers().get_first_value("Subject").unwrap().unwrap(), "Test");
     /// ```
-    fn get_first_value(&self, key: &str) -> Option<String> {
+    fn get_first_value(&self, key: &str) -> Option<Result<String>> {
         self.headers.get_first_value(key)
     }
 
@@ -107,10 +107,14 @@ impl<'a> MailHeaderMap for Headers<'a> {
     ///             "Key: Value1\n",
     ///             "Key: Value2").as_bytes())
     ///         .unwrap();
-    ///     assert_eq!(mail.get_headers().get_all_values("Key"),
-    ///         vec!["Value1".to_string(), "Value2".to_string()]);
+    ///     assert_eq!(
+    ///         mail.get_headers().get_all_values("Key")
+    ///         .into_iter()
+    ///         .collect::<Result<Vec<_>, _>>()
+    ///         .unwrap(),
+    ///         vec!["Value1", "Value2"]);
     /// ```
-    fn get_all_values(&self, key: &str) -> Vec<String> {
+    fn get_all_values(&self, key: &str) -> Vec<Result<String>> {
         self.headers.get_all_values(key)
     }
 

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -53,7 +53,7 @@ impl<'a> IntoIterator for Headers<'a> {
     type IntoIter = slice::Iter<'a, MailHeader<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.headers.into_iter()
+        self.headers.iter()
     }
 }
 

--- a/src/msgidparse.rs
+++ b/src/msgidparse.rs
@@ -57,7 +57,7 @@ pub fn msgidparse(ids: &str) -> Result<MessageIdList, MailParseError> {
     // The remaining section of the header, not yet chomped
     let mut remaining = ids.trim_start();
     // While we have some value of the header remaining
-    while remaining.len() > 0 {
+    while !remaining.is_empty() {
         // The next character should be the start of a Message ID
         if !remaining.starts_with('<') {
             return Err(MailParseError::Generic("Message IDs must start with <"));
@@ -65,11 +65,11 @@ pub fn msgidparse(ids: &str) -> Result<MessageIdList, MailParseError> {
         // The ID ends at the next '>'
         let end_index = remaining
             .find('>')
-            .ok_or_else(|| MailParseError::Generic("Message IDs must end with >"))?;
+            .ok_or(MailParseError::Generic("Message IDs must end with >"))?;
         msgids.push(remaining[1..end_index].to_string());
 
         // Chomp the part of the string we just processed, and any trailing whitespace
-        remaining = &remaining[end_index + 1..].trim_start();
+        remaining = remaining[end_index + 1..].trim_start();
     }
     Ok(MessageIdList(msgids))
 }


### PR DESCRIPTION
This change has the side-effect of making the methods to get header keys and values fallible, which slightly complicates the API but accurately reflects the possibility of encoding errors in header data.

Resolves #102.