### PR TITLE
Upgrade to quoted-printable 0.4.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 data-encoding = "2.3.3"
-quoted_printable = "0.4.6"
+quoted_printable = "0.4.8"
 charset = "0.1.3"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,7 +922,7 @@ impl<'a> Iterator for PartsIterator<'a> {
 ///         Some("This is a test email".to_string()));
 ///     assert_eq!(parsed.subparts.len(), 2);
 ///     assert_eq!(parsed.subparts[0].get_body().unwrap(),
-///         "This is the plaintext version, in utf-8. Proof by Euro: \u{20AC}");
+///         "This is the plaintext version, in utf-8. Proof by Euro: \u{20AC}\r\n");
 ///     assert_eq!(parsed.subparts[1].headers[1].get_value(), "base64");
 ///     assert_eq!(parsed.subparts[1].ctype.mimetype, "text/html");
 ///     assert!(parsed.subparts[1].get_body().unwrap().starts_with("<html>"));


### PR DESCRIPTION
There was a change in behaviour in quoted-printable 0.4.7 which caused one of the doc-tests to fail. This updates the minimum quoted-printable version and updates the doc-test to match the new (more correct) behaviour.

Fixes #119.