### PR TITLE
Use BASE64_MIME_PERMISSIVE to allow trailing bits in b64 data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [".gitattributes", ".gitignore", ".github/**", "examples/**"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-data-encoding = "2.3.3"
+data-encoding = "2.6.0"
 quoted_printable = "0.5.0"
 charset = "0.1.3"
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,5 +1,6 @@
-use crate::{MailParseError, ParsedContentType};
 use charset::{decode_ascii, Charset};
+
+use crate::{MailParseError, ParsedContentType};
 
 /// Represents the body of an email (or mail subpart)
 pub enum Body<'a> {
@@ -141,7 +142,7 @@ fn decode_base64(body: &[u8]) -> Result<Vec<u8>, MailParseError> {
         .filter(|c| !c.is_ascii_whitespace())
         .cloned()
         .collect::<Vec<u8>>();
-    Ok(data_encoding::BASE64_MIME.decode(&cleaned)?)
+    Ok(data_encoding::BASE64_MIME_PERMISSIVE.decode(&cleaned)?)
 }
 
 fn decode_quoted_printable(body: &[u8]) -> Result<Vec<u8>, MailParseError> {

--- a/src/header.rs
+++ b/src/header.rs
@@ -45,7 +45,9 @@ fn decode_word(encoded: &str) -> Option<String> {
     let input = &encoded[ix_delim2 + 1..];
 
     let decoded = match transfer_coding {
-        "B" | "b" => data_encoding::BASE64_MIME.decode(input.as_bytes()).ok()?,
+        "B" | "b" => data_encoding::BASE64_MIME_PERMISSIVE
+            .decode(input.as_bytes())
+            .ok()?,
         "Q" | "q" => {
             // The quoted_printable module does a trim_end on the input, so if
             // that affects the output we should save and restore the trailing


### PR DESCRIPTION
This uses the updated data-encoding crate that introduced the new functionality in https://github.com/ia0/data-encoding/pull/104