### PR TITLE
add recursion limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1910,6 +1910,14 @@ mod tests {
     }
 
     #[test]
+    fn test_recursion_limit() {
+        let mail_filepath = "./tests/files/nested.eml";
+        let mail = std::fs::read(mail_filepath)
+            .expect(&format!("Unable to open the file [{}]", mail_filepath));
+        parse_mail(&mail).err().unwrap();
+    }
+
+    #[test]
     fn test_body_content_encoding_with_multipart() {
         let mail_filepath = "./tests/files/test_email_01.txt";
         let mail = std::fs::read(mail_filepath)

--- a/tests/files/nested.eml
+++ b/tests/files/nested.eml
@@ -1,0 +1,532 @@
+From: you@example.com
+To: me@example.com
+Subject: recursion test
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="B93b885adfe0da089cdf634904fd59f71"
+
+--B93b885adfe0da089cdf634904fd59f71
+Content-Type: multipart/mixed; boundary="B55a54008ad1ba589aa210d2629c1df41"
+
+--B55a54008ad1ba589aa210d2629c1df41
+Content-Type: multipart/mixed; boundary="B9e688c58a5487b8eaf69c9e1005ad0bf"
+
+--B9e688c58a5487b8eaf69c9e1005ad0bf
+Content-Type: multipart/mixed; boundary="B8666683506aacd900bbd5a74ac4edf68"
+
+--B8666683506aacd900bbd5a74ac4edf68
+Content-Type: multipart/mixed; boundary="Bec7f7e7bb43742ce868145f71d37b53c"
+
+--Bec7f7e7bb43742ce868145f71d37b53c
+Content-Type: multipart/mixed; boundary="B8bb6c17838643f9691cc6a4de6c51709"
+
+--B8bb6c17838643f9691cc6a4de6c51709
+Content-Type: multipart/mixed; boundary="B06eca1b437c7904cc3ce6546c8110110"
+
+--B06eca1b437c7904cc3ce6546c8110110
+Content-Type: multipart/mixed; boundary="B89e74e640b8c46257a29de0616794d5d"
+
+--B89e74e640b8c46257a29de0616794d5d
+Content-Type: multipart/mixed; boundary="Be2ba905bf306f46faca223d3cb20e2cf"
+
+--Be2ba905bf306f46faca223d3cb20e2cf
+Content-Type: multipart/mixed; boundary="B5e732a1878be2342dbfeff5fe3ca5aa3"
+
+--B5e732a1878be2342dbfeff5fe3ca5aa3
+Content-Type: multipart/mixed; boundary="B68b329da9893e34099c7d8ad5cb9c940"
+
+--B68b329da9893e34099c7d8ad5cb9c940
+Content-Type: multipart/mixed; boundary="B13c8ffd977013703a701cf8e11deac65"
+
+--B13c8ffd977013703a701cf8e11deac65
+Content-Type: multipart/mixed; boundary="B58c89562f58fd276f592420068db8c09"
+
+--B58c89562f58fd276f592420068db8c09
+Content-Type: multipart/mixed; boundary="Bdcb9be2f604e5df91deb9659bed4748d"
+
+--Bdcb9be2f604e5df91deb9659bed4748d
+Content-Type: multipart/mixed; boundary="B4dedb2240a1e0f038dcdc8b3de92264c"
+
+--B4dedb2240a1e0f038dcdc8b3de92264c
+Content-Type: multipart/mixed; boundary="Bd838691e5d4ad06879ca721442e883d4"
+
+--Bd838691e5d4ad06879ca721442e883d4
+Content-Type: multipart/mixed; boundary="B6b31bdfa7f9bfece263381ffa91bd6a9"
+
+--B6b31bdfa7f9bfece263381ffa91bd6a9
+Content-Type: multipart/mixed; boundary="B47ed733b8d10be225eceba344d533586"
+
+--B47ed733b8d10be225eceba344d533586
+Content-Type: multipart/mixed; boundary="Ba8445619abd08f3ba0ebfcb31183f7f9"
+
+--Ba8445619abd08f3ba0ebfcb31183f7f9
+Content-Type: multipart/mixed; boundary="Bffe51d3e7d8297237588704eeddc6ab2"
+
+--Bffe51d3e7d8297237588704eeddc6ab2
+Content-Type: multipart/mixed; boundary="B15f41a2e96bae341dde485bb0e78f485"
+
+--B15f41a2e96bae341dde485bb0e78f485
+Content-Type: multipart/mixed; boundary="Bf5a7e477cd3042b49a9085d62307cd28"
+
+--Bf5a7e477cd3042b49a9085d62307cd28
+Content-Type: multipart/mixed; boundary="Bbf6d6c819ec975b043aec502167c3d15"
+
+--Bbf6d6c819ec975b043aec502167c3d15
+Content-Type: multipart/mixed; boundary="B84ff14fa45be3ca4739e7c027717a541"
+
+--B84ff14fa45be3ca4739e7c027717a541
+Content-Type: multipart/mixed; boundary="Bcba81acd53fd7719f0aa9495935a872b"
+
+--Bcba81acd53fd7719f0aa9495935a872b
+Content-Type: multipart/mixed; boundary="Be5ea7fb51ff27a20c3f622df66b9acdc"
+
+--Be5ea7fb51ff27a20c3f622df66b9acdc
+Content-Type: multipart/mixed; boundary="Bbebe43a13d6320b4c6751958bf5398a7"
+
+--Bbebe43a13d6320b4c6751958bf5398a7
+Content-Type: multipart/mixed; boundary="Bf616c83f2f0f188265c7004d81d45723"
+
+--Bf616c83f2f0f188265c7004d81d45723
+Content-Type: multipart/mixed; boundary="B0398b4090f24adbccc218219f5746b10"
+
+--B0398b4090f24adbccc218219f5746b10
+Content-Type: multipart/mixed; boundary="Beb259edbaa608eb2208046619b484668"
+
+--Beb259edbaa608eb2208046619b484668
+Content-Type: multipart/mixed; boundary="B7bc72a0767d237be4da30ace191acdc2"
+
+--B7bc72a0767d237be4da30ace191acdc2
+Content-Type: multipart/mixed; boundary="Bad1e41cebd43e64af1a28d4d70dc9e30"
+
+--Bad1e41cebd43e64af1a28d4d70dc9e30
+Content-Type: multipart/mixed; boundary="B7215ee9c7d9dc229d2921a40e899ec5f"
+
+--B7215ee9c7d9dc229d2921a40e899ec5f
+Content-Type: multipart/mixed; boundary="B9033e0e305f247c0c3c80d0c7848c8b3"
+
+--B9033e0e305f247c0c3c80d0c7848c8b3
+Content-Type: multipart/mixed; boundary="Bb15835f133ff2e27c7cb28117bfae8f4"
+
+--Bb15835f133ff2e27c7cb28117bfae8f4
+Content-Type: multipart/mixed; boundary="B01abfc750a0c942167651c40d088531d"
+
+--B01abfc750a0c942167651c40d088531d
+Content-Type: multipart/mixed; boundary="Bc3e97dd6e97fb5125688c97f36720cbe"
+
+--Bc3e97dd6e97fb5125688c97f36720cbe
+Content-Type: multipart/mixed; boundary="B0bcef9c45bd8a48eda1b26eb0c61c869"
+
+--B0bcef9c45bd8a48eda1b26eb0c61c869
+Content-Type: multipart/mixed; boundary="B6cff047854f19ac2aa52aac51bf3af4a"
+
+--B6cff047854f19ac2aa52aac51bf3af4a
+Content-Type: multipart/mixed; boundary="B3590cb8af0bbb9e78c343b52b93773c9"
+
+--B3590cb8af0bbb9e78c343b52b93773c9
+Content-Type: multipart/mixed; boundary="B84c40473414caf2ed4a7b1283e48bbf4"
+
+--B84c40473414caf2ed4a7b1283e48bbf4
+Content-Type: multipart/mixed; boundary="B9371d7a2e3ae86a00aab4771e39d255d"
+
+--B9371d7a2e3ae86a00aab4771e39d255d
+Content-Type: multipart/mixed; boundary="B3389dae361af79b04c9c8e7057f60cc6"
+
+--B3389dae361af79b04c9c8e7057f60cc6
+Content-Type: multipart/mixed; boundary="B26b17225b626fb9238849fd60eabdf60"
+
+--B26b17225b626fb9238849fd60eabdf60
+Content-Type: multipart/mixed; boundary="Bc0cb5f0fcf239ab3d9c1fcd31fff1efc"
+
+--Bc0cb5f0fcf239ab3d9c1fcd31fff1efc
+Content-Type: multipart/mixed; boundary="B336d5ebc5436534e61d16e63ddfca327"
+
+--B336d5ebc5436534e61d16e63ddfca327
+Content-Type: multipart/mixed; boundary="B5058f1af8388633f609cadb75a75dc9d"
+
+--B5058f1af8388633f609cadb75a75dc9d
+Content-Type: multipart/mixed; boundary="B6666cd76f96956469e7be39d750cc7d9"
+
+--B6666cd76f96956469e7be39d750cc7d9
+Content-Type: multipart/mixed; boundary="Bcfcd208495d565ef66e7dff9f98764da"
+
+--Bcfcd208495d565ef66e7dff9f98764da
+Content-Type: multipart/mixed; boundary="Bc4ca4238a0b923820dcc509a6f75849b"
+
+--Bc4ca4238a0b923820dcc509a6f75849b
+Content-Type: multipart/mixed; boundary="Bc81e728d9d4c2f636f067f89cc14862c"
+
+--Bc81e728d9d4c2f636f067f89cc14862c
+Content-Type: multipart/mixed; boundary="Beccbc87e4b5ce2fe28308fd9f2a7baf3"
+
+--Beccbc87e4b5ce2fe28308fd9f2a7baf3
+Content-Type: multipart/mixed; boundary="Ba87ff679a2f3e71d9181a67b7542122c"
+
+--Ba87ff679a2f3e71d9181a67b7542122c
+Content-Type: multipart/mixed; boundary="Be4da3b7fbbce2345d7772b0674a318d5"
+
+--Be4da3b7fbbce2345d7772b0674a318d5
+Content-Type: multipart/mixed; boundary="B1679091c5a880faf6fb5e6087eb1b2dc"
+
+--B1679091c5a880faf6fb5e6087eb1b2dc
+Content-Type: multipart/mixed; boundary="B8f14e45fceea167a5a36dedd4bea2543"
+
+--B8f14e45fceea167a5a36dedd4bea2543
+Content-Type: multipart/mixed; boundary="Bc9f0f895fb98ab9159f51fd0297e236d"
+
+--Bc9f0f895fb98ab9159f51fd0297e236d
+Content-Type: multipart/mixed; boundary="B45c48cce2e2d7fbdea1afc51c7c6ad26"
+
+--B45c48cce2e2d7fbdea1afc51c7c6ad26
+Content-Type: multipart/mixed; boundary="B853ae90f0351324bd73ea615e6487517"
+
+--B853ae90f0351324bd73ea615e6487517
+Content-Type: multipart/mixed; boundary="B9eecb7db59d16c80417c72d1e1f4fbf1"
+
+--B9eecb7db59d16c80417c72d1e1f4fbf1
+Content-Type: multipart/mixed; boundary="B524a50782178998021a88b8cd4c8dcd8"
+
+--B524a50782178998021a88b8cd4c8dcd8
+Content-Type: multipart/mixed; boundary="B43ec3e5dee6e706af7766fffea512721"
+
+--B43ec3e5dee6e706af7766fffea512721
+Content-Type: multipart/mixed; boundary="Bcedf8da05466bb54708268b3c694a78f"
+
+--Bcedf8da05466bb54708268b3c694a78f
+Content-Type: multipart/mixed; boundary="Bd1457b72c3fb323a2671125aef3eab5d"
+
+--Bd1457b72c3fb323a2671125aef3eab5d
+Content-Type: multipart/mixed; boundary="B518ed29525738cebdac49c49e60ea9d3"
+
+--B518ed29525738cebdac49c49e60ea9d3
+Content-Type: multipart/mixed; boundary="B7fc56270e7a70fa81a5935b72eacbe29"
+
+--B7fc56270e7a70fa81a5935b72eacbe29
+Content-Type: multipart/mixed; boundary="B9d5ed678fe57bcca610140957afab571"
+
+--B9d5ed678fe57bcca610140957afab571
+Content-Type: multipart/mixed; boundary="B0d61f8370cad1d412f80b84d143e1257"
+
+--B0d61f8370cad1d412f80b84d143e1257
+Content-Type: multipart/mixed; boundary="Bf623e75af30e62bbd73d6df5b50bb7b5"
+
+--Bf623e75af30e62bbd73d6df5b50bb7b5
+Content-Type: multipart/mixed; boundary="B3a3ea00cfc35332cedf6e5e9a32e94da"
+
+--B3a3ea00cfc35332cedf6e5e9a32e94da
+Content-Type: multipart/mixed; boundary="B800618943025315f869e4e1f09471012"
+
+--B800618943025315f869e4e1f09471012
+Content-Type: multipart/mixed; boundary="Bdfcf28d0734569a6a693bc8194de62bf"
+
+--Bdfcf28d0734569a6a693bc8194de62bf
+Content-Type: multipart/mixed; boundary="Bc1d9f50f86825a1a2302ec2449c17196"
+
+--Bc1d9f50f86825a1a2302ec2449c17196
+Content-Type: multipart/mixed; boundary="Bdd7536794b63bf90eccfd37f9b147d7f"
+
+--Bdd7536794b63bf90eccfd37f9b147d7f
+Content-Type: multipart/mixed; boundary="Bff44570aca8241914870afbc310cdb85"
+
+--Bff44570aca8241914870afbc310cdb85
+Content-Type: multipart/mixed; boundary="Ba5f3c6a11b03839d46af9fb43c97c188"
+
+--Ba5f3c6a11b03839d46af9fb43c97c188
+Content-Type: multipart/mixed; boundary="Bd20caec3b48a1eef164cb4ca81ba2587"
+
+--Bd20caec3b48a1eef164cb4ca81ba2587
+Content-Type: multipart/mixed; boundary="B69691c7bdcc3ce6d5d8a1361f22d04ac"
+
+--B69691c7bdcc3ce6d5d8a1361f22d04ac
+Content-Type: multipart/mixed; boundary="B8d9c307cb7f3c4a32822a51922d1ceaa"
+
+--B8d9c307cb7f3c4a32822a51922d1ceaa
+Content-Type: multipart/mixed; boundary="Bf186217753c37b9b9f958d906208506e"
+
+--Bf186217753c37b9b9f958d906208506e
+Content-Type: multipart/mixed; boundary="B44c29edb103a2872f519ad0c9a0fdaaa"
+
+--B44c29edb103a2872f519ad0c9a0fdaaa
+Content-Type: multipart/mixed; boundary="Bf09564c9ca56850d4cd6b3319e541aee"
+
+--Bf09564c9ca56850d4cd6b3319e541aee
+Content-Type: multipart/mixed; boundary="Be1e1d3d40573127e9ee0480caf1283d6"
+
+--Be1e1d3d40573127e9ee0480caf1283d6
+Content-Type: multipart/mixed; boundary="B5dbc98dcc983a70728bd082d1a47546e"
+
+--B5dbc98dcc983a70728bd082d1a47546e
+Content-Type: multipart/mixed; boundary="Bb9ece18c950afbfa6b0fdbfa4ff731d3"
+
+--Bb9ece18c950afbfa6b0fdbfa4ff731d3
+Content-Type: multipart/mixed; boundary="B4c614360da93c0a041b22e537de151eb"
+
+--B4c614360da93c0a041b22e537de151eb
+Content-Type: multipart/mixed; boundary="B5206560a306a2e085a437fd258eb57ce"
+
+--B5206560a306a2e085a437fd258eb57ce
+Content-Type: multipart/mixed; boundary="B61e9c06ea9a85a5088a499df6458d276"
+
+--B61e9c06ea9a85a5088a499df6458d276
+Content-Type: multipart/mixed; boundary="B02129bb861061d1a052c592e2dc6b383"
+
+--B02129bb861061d1a052c592e2dc6b383
+Content-Type: multipart/mixed; boundary="B57cec4137b614c87cb4e24a3d003a3e0"
+
+--B57cec4137b614c87cb4e24a3d003a3e0
+Content-Type: multipart/mixed; boundary="B21c2e59531c8710156d34a3c30ac81d5"
+
+--B21c2e59531c8710156d34a3c30ac81d5
+Content-Type: multipart/mixed; boundary="B815417267f76f6f460a4a61f9db75fdb"
+
+--B815417267f76f6f460a4a61f9db75fdb
+Content-Type: multipart/mixed; boundary="B28d397e87306b8631f3ed80d858d35f0"
+
+--B28d397e87306b8631f3ed80d858d35f0
+Content-Type: multipart/mixed; boundary="B0fbd1776e1ad22c59a7080d35c7fd4db"
+
+--B0fbd1776e1ad22c59a7080d35c7fd4db
+Content-Type: multipart/mixed; boundary="B7e6a2afe551e067a75fafacf47a6d981"
+
+--B7e6a2afe551e067a75fafacf47a6d981
+Content-Type: multipart/mixed; boundary="Bb14a7b8059d9c055954c92674ce60032"
+
+--Bb14a7b8059d9c055954c92674ce60032
+Content-Type: multipart/mixed; boundary="B833344d5e1432da82ef02e1301477ce8"
+
+--B833344d5e1432da82ef02e1301477ce8
+Content-Type: multipart/mixed; boundary="B0cc175b9c0f1b6a831c399e269772661"
+
+--B0cc175b9c0f1b6a831c399e269772661
+Content-Type: multipart/mixed; boundary="B92eb5ffee6ae2fec3ad71c777531578f"
+
+--B92eb5ffee6ae2fec3ad71c777531578f
+Content-Type: multipart/mixed; boundary="B4a8a08f09d37b73795649038408b5f33"
+
+--B4a8a08f09d37b73795649038408b5f33
+Content-Type: multipart/mixed; boundary="B8277e0910d750195b448797616e091ad"
+
+--B8277e0910d750195b448797616e091ad
+Content-Type: multipart/mixed; boundary="Be1671797c52e15f763380b45e841ec32"
+
+--Be1671797c52e15f763380b45e841ec32
+Content-Type: multipart/mixed; boundary="B8fa14cdd754f91cc6554c9e71929cce7"
+
+--B8fa14cdd754f91cc6554c9e71929cce7
+Content-Type: multipart/mixed; boundary="Bb2f5ff47436671b6e533d8dc3614845d"
+
+--Bb2f5ff47436671b6e533d8dc3614845d
+Content-Type: multipart/mixed; boundary="B2510c39011c5be704182423e3a695e91"
+
+--B2510c39011c5be704182423e3a695e91
+Content-Type: text/plain; charset=UTF-8
+
+Hello from the deepest multipart level.
+
+--B2510c39011c5be704182423e3a695e91--
+
+--Bb2f5ff47436671b6e533d8dc3614845d--
+
+--B8fa14cdd754f91cc6554c9e71929cce7--
+
+--Be1671797c52e15f763380b45e841ec32--
+
+--B8277e0910d750195b448797616e091ad--
+
+--B4a8a08f09d37b73795649038408b5f33--
+
+--B92eb5ffee6ae2fec3ad71c777531578f--
+
+--B0cc175b9c0f1b6a831c399e269772661--
+
+--B833344d5e1432da82ef02e1301477ce8--
+
+--Bb14a7b8059d9c055954c92674ce60032--
+
+--B7e6a2afe551e067a75fafacf47a6d981--
+
+--B0fbd1776e1ad22c59a7080d35c7fd4db--
+
+--B28d397e87306b8631f3ed80d858d35f0--
+
+--B815417267f76f6f460a4a61f9db75fdb--
+
+--B21c2e59531c8710156d34a3c30ac81d5--
+
+--B57cec4137b614c87cb4e24a3d003a3e0--
+
+--B02129bb861061d1a052c592e2dc6b383--
+
+--B61e9c06ea9a85a5088a499df6458d276--
+
+--B5206560a306a2e085a437fd258eb57ce--
+
+--B4c614360da93c0a041b22e537de151eb--
+
+--Bb9ece18c950afbfa6b0fdbfa4ff731d3--
+
+--B5dbc98dcc983a70728bd082d1a47546e--
+
+--Be1e1d3d40573127e9ee0480caf1283d6--
+
+--Bf09564c9ca56850d4cd6b3319e541aee--
+
+--B44c29edb103a2872f519ad0c9a0fdaaa--
+
+--Bf186217753c37b9b9f958d906208506e--
+
+--B8d9c307cb7f3c4a32822a51922d1ceaa--
+
+--B69691c7bdcc3ce6d5d8a1361f22d04ac--
+
+--Bd20caec3b48a1eef164cb4ca81ba2587--
+
+--Ba5f3c6a11b03839d46af9fb43c97c188--
+
+--Bff44570aca8241914870afbc310cdb85--
+
+--Bdd7536794b63bf90eccfd37f9b147d7f--
+
+--Bc1d9f50f86825a1a2302ec2449c17196--
+
+--Bdfcf28d0734569a6a693bc8194de62bf--
+
+--B800618943025315f869e4e1f09471012--
+
+--B3a3ea00cfc35332cedf6e5e9a32e94da--
+
+--Bf623e75af30e62bbd73d6df5b50bb7b5--
+
+--B0d61f8370cad1d412f80b84d143e1257--
+
+--B9d5ed678fe57bcca610140957afab571--
+
+--B7fc56270e7a70fa81a5935b72eacbe29--
+
+--B518ed29525738cebdac49c49e60ea9d3--
+
+--Bd1457b72c3fb323a2671125aef3eab5d--
+
+--Bcedf8da05466bb54708268b3c694a78f--
+
+--B43ec3e5dee6e706af7766fffea512721--
+
+--B524a50782178998021a88b8cd4c8dcd8--
+
+--B9eecb7db59d16c80417c72d1e1f4fbf1--
+
+--B853ae90f0351324bd73ea615e6487517--
+
+--B45c48cce2e2d7fbdea1afc51c7c6ad26--
+
+--Bc9f0f895fb98ab9159f51fd0297e236d--
+
+--B8f14e45fceea167a5a36dedd4bea2543--
+
+--B1679091c5a880faf6fb5e6087eb1b2dc--
+
+--Be4da3b7fbbce2345d7772b0674a318d5--
+
+--Ba87ff679a2f3e71d9181a67b7542122c--
+
+--Beccbc87e4b5ce2fe28308fd9f2a7baf3--
+
+--Bc81e728d9d4c2f636f067f89cc14862c--
+
+--Bc4ca4238a0b923820dcc509a6f75849b--
+
+--Bcfcd208495d565ef66e7dff9f98764da--
+
+--B6666cd76f96956469e7be39d750cc7d9--
+
+--B5058f1af8388633f609cadb75a75dc9d--
+
+--B336d5ebc5436534e61d16e63ddfca327--
+
+--Bc0cb5f0fcf239ab3d9c1fcd31fff1efc--
+
+--B26b17225b626fb9238849fd60eabdf60--
+
+--B3389dae361af79b04c9c8e7057f60cc6--
+
+--B9371d7a2e3ae86a00aab4771e39d255d--
+
+--B84c40473414caf2ed4a7b1283e48bbf4--
+
+--B3590cb8af0bbb9e78c343b52b93773c9--
+
+--B6cff047854f19ac2aa52aac51bf3af4a--
+
+--B0bcef9c45bd8a48eda1b26eb0c61c869--
+
+--Bc3e97dd6e97fb5125688c97f36720cbe--
+
+--B01abfc750a0c942167651c40d088531d--
+
+--Bb15835f133ff2e27c7cb28117bfae8f4--
+
+--B9033e0e305f247c0c3c80d0c7848c8b3--
+
+--B7215ee9c7d9dc229d2921a40e899ec5f--
+
+--Bad1e41cebd43e64af1a28d4d70dc9e30--
+
+--B7bc72a0767d237be4da30ace191acdc2--
+
+--Beb259edbaa608eb2208046619b484668--
+
+--B0398b4090f24adbccc218219f5746b10--
+
+--Bf616c83f2f0f188265c7004d81d45723--
+
+--Bbebe43a13d6320b4c6751958bf5398a7--
+
+--Be5ea7fb51ff27a20c3f622df66b9acdc--
+
+--Bcba81acd53fd7719f0aa9495935a872b--
+
+--B84ff14fa45be3ca4739e7c027717a541--
+
+--Bbf6d6c819ec975b043aec502167c3d15--
+
+--Bf5a7e477cd3042b49a9085d62307cd28--
+
+--B15f41a2e96bae341dde485bb0e78f485--
+
+--Bffe51d3e7d8297237588704eeddc6ab2--
+
+--Ba8445619abd08f3ba0ebfcb31183f7f9--
+
+--B47ed733b8d10be225eceba344d533586--
+
+--B6b31bdfa7f9bfece263381ffa91bd6a9--
+
+--Bd838691e5d4ad06879ca721442e883d4--
+
+--B4dedb2240a1e0f038dcdc8b3de92264c--
+
+--Bdcb9be2f604e5df91deb9659bed4748d--
+
+--B58c89562f58fd276f592420068db8c09--
+
+--B13c8ffd977013703a701cf8e11deac65--
+
+--B68b329da9893e34099c7d8ad5cb9c940--
+
+--B5e732a1878be2342dbfeff5fe3ca5aa3--
+
+--Be2ba905bf306f46faca223d3cb20e2cf--
+
+--B89e74e640b8c46257a29de0616794d5d--
+
+--B06eca1b437c7904cc3ce6546c8110110--
+
+--B8bb6c17838643f9691cc6a4de6c51709--
+
+--Bec7f7e7bb43742ce868145f71d37b53c--
+
+--B8666683506aacd900bbd5a74ac4edf68--
+
+--B9e688c58a5487b8eaf69c9e1005ad0bf--
+
+--B55a54008ad1ba589aa210d2629c1df41--
+
+--B93b885adfe0da089cdf634904fd59f71--


### PR DESCRIPTION
This PR adds a recursion depth limit to prevent unbounded recursion when parsing deeply nested messages. I chose the limit of 255 rather arbitrarely. Let me know what you think.

I also wasn't sure how best to expose this to the public api. I was thinking maybe a new function `parse_mail_limit`? 