### PR TITLE
Add support for IPv6 hostnames in addrparse

### DIFF
--- a/src/addrparse.rs
+++ b/src/addrparse.rs
@@ -579,7 +579,7 @@ fn addrparse_inner(
                             // Technically not valid, but occurs in real-world corpus, so handle it gracefully
                             state = AddrParseState::Initial;
                             addr = None;
-                        } else if c == ':' {
+                        } else if c == ':' && !addr.as_ref().map_or(false, |s| s.contains('@')) {
                             if in_group {
                                 return Err(MailParseError::Generic(
                                     "Found unexpected nested group",
@@ -1099,6 +1099,46 @@ mod tests {
                     .unwrap()
                 )
             ])
+        );
+    }
+
+    #[test]
+    fn parse_ip_hostnames() {
+        assert_eq!(
+            addrparse("<test@example.org>").unwrap(),
+            MailAddrList(vec![MailAddr::Single(
+                SingleInfo::new(None, "test@example.org".to_string()).unwrap()
+            )])
+        );
+        assert_eq!(
+            addrparse("<test@[192.0.2.0]>").unwrap(),
+            MailAddrList(vec![MailAddr::Single(
+                SingleInfo::new(None, "test@[192.0.2.0]".to_string()).unwrap()
+            )])
+        );
+        assert_eq!(
+            addrparse("<test@[IPv6:2001:db8::1]>").unwrap(),
+            MailAddrList(vec![MailAddr::Single(
+                SingleInfo::new(None, "test@[IPv6:2001:db8::1]".to_string()).unwrap()
+            )])
+        );
+        assert_eq!(
+            addrparse("test@example.org").unwrap(),
+            MailAddrList(vec![MailAddr::Single(
+                SingleInfo::new(None, "test@example.org".to_string()).unwrap()
+            )])
+        );
+        assert_eq!(
+            addrparse("test@[192.0.2.0]").unwrap(),
+            MailAddrList(vec![MailAddr::Single(
+                SingleInfo::new(None, "test@[192.0.2.0]".to_string()).unwrap()
+            )])
+        );
+        assert_eq!(
+            addrparse("test@[IPv6:2001:db8::1]").unwrap(),
+            MailAddrList(vec![MailAddr::Single(
+                SingleInfo::new(None, "test@[IPv6:2001:db8::1]".to_string()).unwrap()
+            )])
         );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/staktrace/mailparse/issues/137

The colon character in IPv6 hostnames normally gets interpreted as a group delimeter, but group names cannot contain '@' characters. So if we encounter a colon and previously encountered an '@' then don't treat the colon as a group delimiter and just treat it as part of the address.