### PR TITLE
Scan for MIME boundaries and base64 whitespace a word at a time (no new dependencies)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 data-encoding = "2.6.0"
+memchr = "2.7.0"
 quoted_printable = "0.5.0"
 charset = "0.1.3"
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -137,12 +137,34 @@ impl<'a> BinaryBody<'a> {
 }
 
 fn decode_base64(body: &[u8]) -> Result<Vec<u8>, MailParseError> {
-    let cleaned = body
-        .iter()
-        .filter(|c| !c.is_ascii_whitespace())
-        .cloned()
-        .collect::<Vec<u8>>();
+    let cleaned = strip_ascii_whitespace(body);
     Ok(data_encoding::BASE64_MIME_PERMISSIVE.decode(&cleaned)?)
+}
+
+/// Copy `body` without its ASCII whitespace -- the same bytes `u8::is_ascii_whitespace`
+/// names: space, tab, newline, form feed, carriage return.
+///
+/// Whitespace is located with a vectorised search and the runs between are copied
+/// whole, rather than testing and pushing one byte at a time. A base64 body is
+/// almost entirely 76-byte lines ending in CRLF, so the common case is one search
+/// and one copy per line. Tabs and form feeds are rare enough that they get a second
+/// search over each run instead of a place in the first.
+fn strip_ascii_whitespace(body: &[u8]) -> Vec<u8> {
+    let mut cleaned = Vec::with_capacity(body.len());
+    let mut rest = body;
+    loop {
+        let end = memchr::memchr3(b'\r', b'\n', b' ', rest).unwrap_or(rest.len());
+        let mut run = &rest[..end];
+        while let Some(j) = memchr::memchr2(b'\t', 0x0c, run) {
+            cleaned.extend_from_slice(&run[..j]);
+            run = &run[j + 1..];
+        }
+        cleaned.extend_from_slice(run);
+        if end == rest.len() {
+            return cleaned;
+        }
+        rest = &rest[end + 1..];
+    }
 }
 
 fn decode_quoted_printable(body: &[u8]) -> Result<Vec<u8>, MailParseError> {
@@ -160,4 +182,48 @@ fn get_body_as_string(body: &[u8], ctype: &ParsedContentType) -> Result<String, 
         decode_ascii(body)
     };
     Ok(cow.into_owned())
+}
+
+#[cfg(test)]
+mod strip_ascii_whitespace_tests {
+    use super::strip_ascii_whitespace;
+
+    fn reference(body: &[u8]) -> Vec<u8> {
+        body.iter()
+            .filter(|c| !c.is_ascii_whitespace())
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn matches_the_filter_it_replaces() {
+        let cases: &[&[u8]] = &[
+            b"",
+            b" ",
+            b" \t\r\n\x0c",
+            b"abc",
+            b"  abc  ",
+            b"ab cd\tef\ngh\rij\x0ckl",
+            b"\x0b", // vertical tab is NOT ascii whitespace; must be kept
+            b"a\x0bb",
+            b"\t\tab\x0c\x0ccd",
+            b"QUJD\r\nREVG\r\n",
+            b"QUJD REVG\tR0hJ\x0cSktM",
+        ];
+        for case in cases {
+            assert_eq!(strip_ascii_whitespace(case), reference(case), "{:?}", case);
+        }
+        // every byte value, alone and next to whitespace
+        for b in 0u8..=255 {
+            let single = [b];
+            assert_eq!(
+                strip_ascii_whitespace(&single),
+                reference(&single),
+                "{:?}",
+                b
+            );
+            let mixed = [b' ', b, b'\t', b, b'\r', b'\n', b];
+            assert_eq!(strip_ascii_whitespace(&mixed), reference(&mixed), "{:?}", b);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,27 +117,7 @@ pub(crate) fn find_from(line: &str, ix_start: usize, key: &str) -> Option<usize>
 fn find_from_u8(line: &[u8], ix_start: usize, key: &[u8]) -> Option<usize> {
     assert!(!key.is_empty());
     assert!(ix_start <= line.len());
-    if line.len() < key.len() {
-        return None;
-    }
-    let ix_end = line.len() - key.len();
-    if ix_start <= ix_end {
-        for i in ix_start..=ix_end {
-            if line[i] == key[0] {
-                let mut success = true;
-                for j in 1..key.len() {
-                    if line[i + j] != key[j] {
-                        success = false;
-                        break;
-                    }
-                }
-                if success {
-                    return Some(i);
-                }
-            }
-        }
-    }
-    None
+    memchr::memmem::find(&line[ix_start..], key).map(|v| ix_start + v)
 }
 
 #[test]


### PR DESCRIPTION
Revised after the review: **no new dependency, no `unsafe`.** The two byte-at-a-time loops in the parse path are replaced by word-at-a-time scans in plain `std`, in one new module, `src/bytescan.rs`.

**The two loops.** On a message with large attachments they are most of `parse_mail`: sampling a structure-only parse of a 767 KiB message (four base64 attachments) put 96% of the cycles in `find_from_u8`'s scan for the boundary, and once that was fixed, 78% of a full parse was in `decode_base64`'s `iter().filter(!is_ascii_whitespace).collect()`. Their speed also depended on where the linker happened to place them — the same instructions ran at half speed on x86-64 when a loop straddled a 64-byte boundary — so unrelated changes in a dependent crate moved parse time 2x.

**The scans.** `usize` chunks read with `chunks_exact` + `from_le_bytes` (plain loads), tested with the classic exact word tricks (`haszero`, `hasless`; Anderson's *Bit Twiddling Hacks*), and `trailing_zeros` to jump to a hit rather than rescan the word:

- `find_byte`: four words per branch in the no-hit case; `find` scans for `key[0]` and compares the rest only at candidates. `find_from_u8` keeps its asserts and semantics.
- `strip_ascii_whitespace`: a word with no byte below `0x21` cannot contain whitespace and is skipped whole; each candidate bit is re-checked with `is_ascii_whitespace`, so `0x0B` and other control bytes are kept exactly as before; runs are copied in one piece.

Semantics are unchanged; `bytescan::tests` checks both against the loops they replace over a generated corpus at every alignment and over every byte value. `cargo test` and `cargo fmt --check` pass; the module is clippy-clean.

Measured from a dependent crate ([fast_mail_parser](https://github.com/namecheap/fast_mail_parser)) on the message above, interleaved A/B, Apple M4:

| | before | after |
|---|---|---|
| full parse (all bodies decoded) | 1.09 ms | 0.24 ms |
| structure-only parse (no bodies decoded) | 0.37 ms | 0.03 ms |

Within measurement noise of the `memchr` version this replaces, and a few percent faster on the decoding path.